### PR TITLE
Async Iterables

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -20,7 +20,7 @@ nostr.debugMode = true;
 
 await nostr.connect();
 
-for await (const feeds of await nostr.getEventsIterable({ kinds: [NostrKind.TEXT_NOTE], limit: 10 }) ) {
+for await (const feeds of nostr.getEventsIterable({ kinds: [NostrKind.TEXT_NOTE], limit: 10 }) ) {
     console.log(feeds);
 }
 

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -20,6 +20,10 @@ nostr.debugMode = true;
 
 await nostr.connect();
 
+for await (const feeds of await nostr.getEventsIterable({ kinds: [NostrKind.TEXT_NOTE], limit: 10 }) ) {
+    console.log(feeds);
+}
+
 nostr.privateKey = ''; // A private key is optional. Only used for sending posts.
 await nostr.sendTextPost('Hello nostr deno client library.');
 

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,5 +1,5 @@
 import { Nostr, Relay, NostrKind } from 'https://deno.land/x/nostr_deno_client@v0.2.1/mod.ts';
-//import { Nostr, NostrKind } from "../nostr.ts";
+// import { Nostr, NostrKind } from "../nostr.ts";
 
 const nostr = new Nostr();
 
@@ -17,29 +17,34 @@ nostr.on('relayConnected', (relay: Relay) => console.log('Relay connected.', rel
 nostr.on('relayError', (err: Error) => console.log('Relay error;', err));
 nostr.on('relayNotice', (notice: string[]) => console.log('Notice', notice));
 
-nostr.debugMode = true;
+//nostr.debugMode = true;
 
 await nostr.connect();
 
 const filter = { kinds: [NostrKind.TEXT_NOTE], limit: 10 };
 
 //method 1: for await
+console.log('iterable return');
 for await (const note of nostr.filter(filter) ) {
     console.log(note);
 }
 
 //method 2: collect
+console.log('promise return');
 const allNotes = await nostr.filter(filter).collect();
 console.log(allNotes);
 
 //method 3: callback
+console.log('callback return');
 await nostr.filter(filter).each(note => {
     console.log(note);
-})
+});
+
 
 nostr.privateKey = ''; // A private key is optional. Only used for sending posts.
 await nostr.sendTextPost('Hello nostr deno client library.');
 
+nostr.publicKey = ''; // You need a public key for get posts.
 const posts = await nostr.getPosts();
 console.log('Posts', posts);
 

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,4 +1,5 @@
 import { Nostr, Relay, NostrKind } from 'https://deno.land/x/nostr_deno_client@v0.2.1/mod.ts';
+//import { Nostr, NostrKind } from "../nostr.ts";
 
 const nostr = new Nostr();
 
@@ -20,9 +21,21 @@ nostr.debugMode = true;
 
 await nostr.connect();
 
-for await (const feeds of nostr.getEventsIterable({ kinds: [NostrKind.TEXT_NOTE], limit: 10 }) ) {
-    console.log(feeds);
+const filter = { kinds: [NostrKind.TEXT_NOTE], limit: 10 };
+
+//method 1: for await
+for await (const note of nostr.filter(filter) ) {
+    console.log(note);
 }
+
+//method 2: collect
+const allNotes = await nostr.filter(filter).collect();
+console.log(allNotes);
+
+//method 3: callback
+await nostr.filter(filter).each(note => {
+    console.log(note);
+})
 
 nostr.privateKey = ''; // A private key is optional. Only used for sending posts.
 await nostr.sendTextPost('Hello nostr deno client library.');

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -65,7 +65,7 @@ declare interface Nostr {
 
 class Nostr extends EventEmitter {
     public relayList: Array<RelayList> = [];
-    relayInstances: Array<Relay> = [];
+    private relayInstances: Array<Relay> = [];
     private _privateKey: any;
     public publicKey: any;
     public debugMode = false;

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -129,7 +129,7 @@ class Nostr extends EventEmitter {
 
     /**
      * Usage example:
-     * for await (const event of nostr.nostrEvents({
+     * for await (const event of nostr.getEventsIterable({
      *       kinds: [NostrKind.META_DATA],
      *       authors: [publicKey],
      *       limit: 1
@@ -141,7 +141,7 @@ class Nostr extends EventEmitter {
      * @param unique set to true to avoid duplicate results
      * @returns an async iterable over the matching events
      */
-    async * nostrEvents(filters: NostrFilters, unique = false) {
+    async * getEventsIterable(filters: NostrFilters, unique = true) {
         function indexPromise<T>(p: Promise<T>, i: number): Promise<{value: T, i: number}> {
             return new Promise((resolve, reject) => p.then(r => resolve({value: r, i})).catch(reason => reject({reason, i})))
         }

--- a/lib/relay.ts
+++ b/lib/relay.ts
@@ -66,7 +66,7 @@ class Relay {
         await this.ws?.close(1000);
     }
 
-    sendErrorEvent(err: Error) {
+    sendErrorEvent(err: Error){
         this.nostr.emit('relayError', err, this);
     }
 
@@ -123,7 +123,7 @@ class Relay {
     }
 
     public subscribePromise(filters: NostrFilters): Promise<Array<NostrEvent>> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             const subscribeId = crypto.randomUUID();
             let data: string;
             if (Array.isArray(filters)) {

--- a/mod.ts
+++ b/mod.ts
@@ -27542,7 +27542,7 @@ class Nostr extends EventEmitter {
         }
         return events;
     }
-    async *nostrEvents(filters) {
+    async *nostrEvents(filters, unique = false) {
         function indexPromise(p, i) {
             return new Promise((resolve, reject)=>p.then((r)=>resolve({
                         value: r,
@@ -27555,6 +27555,7 @@ class Nostr extends EventEmitter {
         const relayIterators = this.relayInstances.map((r)=>r.events(filters));
         const nextPromises = relayIterators.map((i)=>i.next());
         const indexedPromises = nextPromises.map((p, i)=>indexPromise(p, i));
+        const yieldedEventIds = [];
         while(relayIterators.length > 0){
             const indexResult = await Promise.race(indexedPromises);
             if (indexResult.value.done) {
@@ -27567,7 +27568,12 @@ class Nostr extends EventEmitter {
                     });
                 }
             } else {
-                yield indexResult.value.value;
+                if (!unique || yieldedEventIds.indexOf(indexResult.value.value.id) === -1) {
+                    yield indexResult.value.value;
+                    if (unique) {
+                        yieldedEventIds.push(indexResult.value.value.id);
+                    }
+                }
                 indexedPromises[indexResult.i] = indexPromise(relayIterators[indexResult.i].next(), indexResult.i);
             }
         }

--- a/mod.ts
+++ b/mod.ts
@@ -2290,6 +2290,29 @@ class Relay {
         });
         this.ws?.send(data);
     }
+    async *events(filters) {
+        const buffer = [];
+        let waiter = null;
+        this.subscribe(filters, (e, _end)=>{
+            buffer.push(e);
+            if (waiter) {
+                waiter(true);
+            }
+        });
+        while(true){
+            if (buffer.length === 0) {
+                await new Promise((resolve)=>{
+                    waiter = resolve;
+                });
+            }
+            const firstValue = buffer.shift();
+            if (firstValue === null) {
+                return;
+            } else {
+                yield firstValue;
+            }
+        }
+    }
     subscribePromise(filters) {
         return new Promise((resolve, reject)=>{
             const subscribeId = crypto.randomUUID();
@@ -27518,6 +27541,36 @@ class Nostr extends EventEmitter {
             }
         }
         return events;
+    }
+    async *nostrEvents(filters) {
+        function indexPromise(p, i) {
+            return new Promise((resolve, reject)=>p.then((r)=>resolve({
+                        value: r,
+                        i
+                    })).catch((reason)=>reject({
+                        reason,
+                        i
+                    })));
+        }
+        const relayIterators = this.relayInstances.map((r)=>r.events(filters));
+        const nextPromises = relayIterators.map((i)=>i.next());
+        const indexedPromises = nextPromises.map((p, i)=>indexPromise(p, i));
+        while(relayIterators.length > 0){
+            const indexResult = await Promise.race(indexedPromises);
+            if (indexResult.value.done) {
+                relayIterators.splice(indexResult.i, 1);
+                indexedPromises.splice(indexResult.i, 1);
+                for(let i = indexResult.i; i < indexedPromises.length; i++){
+                    indexedPromises[i] = indexedPromises[i].then((r)=>{
+                        r.i--;
+                        return r;
+                    });
+                }
+            } else {
+                yield indexResult.value.value;
+                indexedPromises[indexResult.i] = indexPromise(relayIterators[indexResult.i].next(), indexResult.i);
+            }
+        }
     }
     async getMyProfile() {
         return await this.getProfile(this.publicKey);


### PR DESCRIPTION
This addresses issues #11 introducing async iterables nostr events that can be consumed as follows:

```
for await (const event of nostr.nostrEvents(filters, true)) {
    console.log('Event', event);
}


for (const relay of nostr.relayInstances) {
    for await (const event of relay.events(filters)) {
        console.log('Event from relay', event);
    }
}
```